### PR TITLE
bugfix : rollback version prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "jest-environment-node": "^29.6.1",
     "nx": "16.5.0",
     "postcss": "^8.4.24",
-    "prettier": "^3.0.0",
+    "prettier": "^2.8.8",
     "prisma": "5",
     "tailwindcss": "^3.3.2",
     "ts-jest": "^29.1.1",


### PR DESCRIPTION
rollback version prettier from 3.0.0 to 2.8.8

![image](https://github.com/himatifdevteam/uninus/assets/92211447/5ee8e6d3-b347-40c1-9009-36297a33ac2c)
