### PR TITLE
Improvement/handle error login

### DIFF
--- a/libs/modules-fe/src/auth/login/module.tsx
+++ b/libs/modules-fe/src/auth/login/module.tsx
@@ -9,6 +9,8 @@ import Link from 'next/link';
 
 export const LoginModule: FC = (): ReactElement => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [emailError, setEmailError] = useState<string>('');
+  const [passwordError, setPasswordError] = useState<string>('');
 
   const {
     control,
@@ -24,14 +26,39 @@ export const LoginModule: FC = (): ReactElement => {
     },
   });
 
-  const onSubmit = handleSubmit((data) => {
-    setIsLoading(true);
-    signIn('login', {
-      callbackUrl: '/dashboard',
-      redirect: true,
-      email: data?.email,
-      password: data?.password,
-    });
+  const onSubmit = handleSubmit(async (data) => {
+    try {
+      setIsLoading(true);
+      const result = await signIn('login', {
+        callbackUrl: '/dashboard',
+        redirect: false,
+        email: data.email,
+        password: data.password,
+      });
+
+      setEmailError('');
+      setPasswordError('');
+
+      if (result?.error === 'Akun tidak ditemukan') {
+        setEmailError('Akun tidak ditemukan');
+      } else if (result?.error === 'Password salah') {
+        setPasswordError('Password salah');
+      } else {
+      }
+
+      if (!result?.error) {
+        signIn('login', {
+          callbackUrl: '/dashboard',
+          redirect: true,
+          email: data.email,
+          password: data.password,
+        });
+      }
+    } catch (error) {
+      console.error('Unexpected error occurred during sign-in:', error);
+    } finally {
+      setIsLoading(false);
+    }
   });
 
   return (
@@ -48,9 +75,7 @@ export const LoginModule: FC = (): ReactElement => {
             Selamat Datang Calon Nusantara Muda
           </p>
         </div>
-        {/* <span className=" mx-auto border border-red-5 my-3  text-red-5 p-1 text-xs rounded-md text-center w-1/3">
-        akun tidak ditemukan
-      </span> */}
+
         <div className="flex flex-col w-full justify-center items-center">
           <div className="justify-center w-full flex flex-col">
             <TextField
@@ -61,8 +86,8 @@ export const LoginModule: FC = (): ReactElement => {
               placeholder="Masukan email"
               control={control}
               required
-              status={errors?.email ? 'error' : undefined}
-              message={errors?.email?.message}
+              status={errors?.email || emailError ? 'error' : undefined}
+              message={errors?.email?.message || emailError}
             />
             <TextField
               name="password"
@@ -72,8 +97,8 @@ export const LoginModule: FC = (): ReactElement => {
               control={control}
               placeholder="Masukan password"
               required
-              status={errors?.password ? 'error' : undefined}
-              message={errors?.password?.message}
+              status={errors?.email || passwordError ? 'error' : undefined}
+              message={errors?.email?.message || passwordError}
             />
           </div>
         </div>

--- a/libs/modules-fe/src/auth/login/module.tsx
+++ b/libs/modules-fe/src/auth/login/module.tsx
@@ -97,8 +97,8 @@ export const LoginModule: FC = (): ReactElement => {
               control={control}
               placeholder="Masukan password"
               required
-              status={errors?.email || passwordError ? 'error' : undefined}
-              message={errors?.email?.message || passwordError}
+              status={errors?.password || passwordError ? 'error' : undefined}
+              message={errors?.password?.message || passwordError}
             />
           </div>
         </div>

--- a/libs/modules-fe/src/auth/login/next-auth.ts
+++ b/libs/modules-fe/src/auth/login/next-auth.ts
@@ -21,7 +21,6 @@ export const authOptions: NextAuthOptions = {
           return data;
         } catch (err) {
           const error = err as TMetaErrorResponse;
-          console.log(error);
           if (error?.response?.status === 422) {
             throw new Error(error.response.data.message);
           }

--- a/libs/modules-fe/src/auth/login/next-auth.ts
+++ b/libs/modules-fe/src/auth/login/next-auth.ts
@@ -21,10 +21,10 @@ export const authOptions: NextAuthOptions = {
           return data;
         } catch (err) {
           const error = err as TMetaErrorResponse;
+          console.log(error);
           if (error?.response?.status === 422) {
             throw new Error(error.response.data.message);
           }
-
           throw new Error(
             typeof error?.response?.data === 'string'
               ? error.response.data

--- a/libs/modules-fe/src/layouts/main.tsx
+++ b/libs/modules-fe/src/layouts/main.tsx
@@ -15,7 +15,7 @@ export const MainLayout: FC<PropsWithChildren> = ({
   }
 
   if (status === 'authenticated') {
-    router.back();
+    router.push('/dashboard');
   }
 
   return (


### PR DESCRIPTION
Bang/teh initeh kan pas login gk ada error handler

![image](https://github.com/himatifdevteam/uninus/assets/108710826/0e7ec5bc-d325-426a-92d3-58de7aa29249)

nah urg nyoba nambah error handler tapi teu ubah nextauth na, ngan nyesuaiken respon na, tapi teu langsung di redirect oge ke dashboard

contoh 
![image](https://github.com/himatifdevteam/uninus/assets/108710826/b7c7bf60-29c6-4350-a99d-53fad52b85f3)
![image](https://github.com/himatifdevteam/uninus/assets/108710826/c6024407-1fa8-4c3f-8f47-d5cd610aa1b1)

udah dicoba buat login pake akun yang benernya tetep jalan